### PR TITLE
Use macro-based type derivations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 # GraphQL Playground
 
 Playground to test and play with GraphQL schema and queries.
+The project utilises Scala and [Sangria - GraphQL Implementation](https://sangria-graphql.github.io/)
 
 ## Run
 

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # GraphQL Playground
 
 Playground to test and play with GraphQL schema and queries.
-The project utilises Scala and [Sangria - GraphQL Implementation](https://sangria-graphql.github.io/)
+The project utilises Scala and [Sangria - GraphQL Implementation](https://sangria-graphql.github.io/).
 
 ## Run
 

--- a/src/main/scala/graphql/SchemaDefinition.scala
+++ b/src/main/scala/graphql/SchemaDefinition.scala
@@ -1,42 +1,39 @@
 package graphql
 
-import models.{Actor, Genre, Language, Movie}
+import models._
+import sangria.macros.derive._
 import sangria.schema._
 import service.MovieServiceImpl
 
 object SchemaDefinition {
-  val GenreEnum: EnumType[Genre] = EnumType(
-    "Genre",
-    Some("Genre of Movie"),
-    Genre.values.map(genre => EnumValue(genre.toString, value = genre)).toList
+  implicit val GenreEnum: EnumType[Genre] = deriveEnumType[Genre](
+    EnumTypeName("Genre"),
+    EnumTypeDescription("Genre of Movie"),
+    RenameValue("Thriller", "Horror")
   )
 
-  val LanguageEnum: EnumType[Language] = EnumType(
-    "Language",
-    Some("Language of Movie"),
-    Language.values.map(language => EnumValue(language.toString, value = language)).toList
+  implicit val LanguageEnum: EnumType[Language] = deriveEnumType[Language](
+    EnumTypeName("Language"),
+    EnumTypeDescription("Language of Movie")
   )
 
-  val ActorType: ObjectType[Unit, Actor] = ObjectType(
-    "Actor",
-    "Actor Information",
-    fields[Unit, Actor](
-      Field("name", StringType, resolve = _.value.name)
+  implicit val ActorType: ObjectType[Unit, Actor] = deriveObjectType[Unit, Actor](
+    ObjectTypeName("Actor"),
+    ObjectTypeDescription("Actor Information"),
+    AddFields(
+      Field("randomNum", FloatType, resolve = _ => Math.random())
     )
   )
 
-  val MovieType: ObjectType[Unit, Movie] = ObjectType(
-    "Movie",
-    "Movie Information",
-    fields[Unit, Movie](
-      Field("title", StringType, resolve = _.value.movieInfo.title),
-      Field("synopsis", StringType, resolve = _.value.movieInfo.synopsis),
-      Field("genre", GenreEnum, resolve = _.value.movieInfo.genre),
-      Field("durationMins", IntType, resolve = _.value.movieInfo.durationMins),
-      Field("releaseDate", StringType, resolve = _.value.movieInfo.releaseDate),
-      Field("language", LanguageEnum, resolve = _.value.movieInfo.language),
-      Field("cast", ListType(ActorType), resolve = _.value.cast)
-    )
+  implicit val MovieInfoType: ObjectType[Unit, MovieInfo] = deriveObjectType[Unit, MovieInfo](
+    ObjectTypeName("MovieInfo"),
+    ObjectTypeDescription("Movie Information"),
+    RenameField("durationMins", "durationInMinutes")
+  )
+
+  val MovieType: ObjectType[Unit, Movie] = deriveObjectType[Unit, Movie](
+    ObjectTypeName("Movie"),
+    ObjectTypeDescription("Movie & Cast Information")
   )
 
   val Id: Argument[Int] = Argument("id", IntType)

--- a/src/test/scala/graphql/SchemaDefinitionSpec.scala
+++ b/src/test/scala/graphql/SchemaDefinitionSpec.scala
@@ -23,9 +23,11 @@ class SchemaDefinitionSpec extends AnyWordSpec with Matchers {
         graphql"""
           query {
             movies {
-              title
-              genre
-              language
+              movieInfo {
+                title
+                genre
+                durationInMinutes
+              }
             }
           }
                """
@@ -35,10 +37,10 @@ class SchemaDefinitionSpec extends AnyWordSpec with Matchers {
           |{
           | "data": {
           |   "movies": [
-          |     { "title": "Spider-Man: No Way Home", "genre": "Action", "language": "English" },
-          |     { "title": "Get Out", "genre": "Thriller", "language": "English" },
-          |     { "title": "Shang-Chi and The Legend of The Ten Rings", "genre": "Action", "language": "English" },
-          |     { "title": "Train to Busan", "genre": "Action", "language": "Korean" }
+          |     { "movieInfo": { "title": "Spider-Man: No Way Home", "genre": "Action", "durationInMinutes": 148 } },
+          |     { "movieInfo": { "title": "Get Out", "genre": "Horror", "durationInMinutes": 104 } },
+          |     { "movieInfo": { "title": "Shang-Chi and The Legend of The Ten Rings", "genre": "Action", "durationInMinutes": 132 } },
+          |     { "movieInfo": { "title": "Train to Busan", "genre": "Action", "durationInMinutes": 118 } }
           |   ]
           | }
           |}
@@ -51,7 +53,9 @@ class SchemaDefinitionSpec extends AnyWordSpec with Matchers {
         graphql"""
           query($$id: Int!) {
             movie(id: $$id) {
-              title
+              movieInfo {
+                title
+              }
               cast {
                 name
               }
@@ -64,7 +68,9 @@ class SchemaDefinitionSpec extends AnyWordSpec with Matchers {
           |{
           | "data": {
           |   "movie": {
-          |     "title": "Shang-Chi and The Legend of The Ten Rings",
+          |     "movieInfo": {
+          |       "title": "Shang-Chi and The Legend of The Ten Rings"
+          |     },
           |     "cast": [
           |       { "name": "Simu Liu" },
           |       { "name": "Awkwafina" },


### PR DESCRIPTION
**Use macro-based type derivations**
Reference: [Sangria: Macro-Based GraphQL Type Derivation](https://sangria-graphql.github.io/learn/#macro-based-graphql-type-derivation)

Derivations used in PR:
- ObjectType
- EnumType